### PR TITLE
added colour to report and sheet

### DIFF
--- a/frontend/src/components/ReportTaskDetailTable.jsx
+++ b/frontend/src/components/ReportTaskDetailTable.jsx
@@ -1,5 +1,11 @@
 import React from "react";
 
+const statusBadgeClass = {
+  Completed: "bg-emerald-100 text-emerald-800 border-emerald-200",
+  Pending: "bg-amber-100 text-amber-800 border-amber-200",
+  "In Progress": "bg-sky-100 text-sky-800 border-sky-200"
+};
+
 const formatDateTime = (value) => {
   if (!value) return "-";
   const date = new Date(value);
@@ -36,7 +42,10 @@ function ReportTaskDetailTable({ tasks = [] }) {
         </thead>
         <tbody>
           {tasks.map((task) => (
-            <tr key={task.id} className="border-b border-slate-200/80">
+            <tr
+              key={task.id}
+              className={`border-b border-slate-200/80 ${task.status === "Completed" ? "bg-emerald-50/30" : task.status === "Pending" ? "bg-amber-50/20" : task.status === "In Progress" ? "bg-sky-50/30" : "bg-white"}`}
+            >
               <td className="px-3 py-2 text-slate-600">{task.id}</td>
               <td className="px-3 py-2 font-medium text-slate-700">{task.assigned_to_name || "-"}</td>
               <td className="px-3 py-2 text-slate-600">{task.assigned_to_team || "-"}</td>
@@ -44,7 +53,7 @@ function ReportTaskDetailTable({ tasks = [] }) {
               <td className="px-3 py-2 text-slate-700">{task.task || "-"}</td>
               <td className="px-3 py-2 text-slate-600">{task.action || "-"}</td>
               <td className="px-3 py-2">
-                <span className="rounded-md bg-slate-100 px-2 py-1 text-xs font-semibold text-slate-700">
+                <span className={`rounded-md border px-2 py-1 text-xs font-semibold ${statusBadgeClass[task.status] || "bg-slate-100 text-slate-700 border-slate-200"}`}>
                   {task.status || "-"}
                 </span>
               </td>

--- a/frontend/src/components/TaskTable.jsx
+++ b/frontend/src/components/TaskTable.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 
 const statusClass = {
   Pending: "bg-yellow-100 text-yellow-800",
-  "In Progress": "bg-yellow-100 text-yellow-800",
+  "In Progress": "bg-sky-100 text-sky-800",
   Completed: "bg-green-100 text-green-800"
 };
 

--- a/frontend/src/pages/ReportPage.jsx
+++ b/frontend/src/pages/ReportPage.jsx
@@ -13,6 +13,7 @@ const COLOR = {
   todayGreen: "FF7CB342",
   receivedGreen: "FF6AA84F",
   completedGreen: "FF34A853",
+  inProgressBlue: "FF3B82F6",
   pendingAmber: "FFF59E0B",
   leaveBlue: "FF4FC3F7",
   notReceivedRed: "FFFF0000",
@@ -391,9 +392,12 @@ function ReportPage({
         pattern: "solid",
         fgColor: { argb: COLOR.headerGray }
       };
+      sheet.getRow(1).eachCell((cell) => {
+        applyCellStyle(cell, { fillColor: COLOR.headerGray, bold: true });
+      });
 
       detailedTasks.forEach((entry) => {
-        sheet.addRow({
+        const row = sheet.addRow({
           "Task ID": entry.id,
           Employee: entry.assigned_to_name || "-",
           Team: entry.assigned_to_team || "-",
@@ -406,6 +410,21 @@ function ReportPage({
           "Created At": formatDateTimeText(entry.created_at),
           "Completed At": formatDateTimeText(entry.completed_at)
         });
+
+        row.eachCell((cell) => {
+          applyCellStyle(cell, { fillColor: COLOR.white, align: "left" });
+        });
+
+        const statusCell = row.getCell(7);
+        if (entry.status === "Completed") {
+          applyCellStyle(statusCell, { fillColor: COLOR.completedGreen, bold: true });
+        } else if (entry.status === "In Progress") {
+          applyCellStyle(statusCell, { fillColor: COLOR.inProgressBlue, bold: true });
+        } else if (entry.status === "Pending") {
+          applyCellStyle(statusCell, { fillColor: COLOR.pendingAmber, bold: true });
+        } else {
+          applyCellStyle(statusCell, { fillColor: COLOR.headerGray, bold: true });
+        }
       });
 
       workbook.xlsx.writeBuffer().then((buffer) => {


### PR DESCRIPTION
This pull request introduces several improvements to the way task statuses are visually represented across the frontend and in exported reports. The main focus is on consistent and clearer color coding for different task statuses ("Completed", "Pending", "In Progress"), both in UI tables and in Excel exports.

**UI Status Color Consistency and Enhancement:**

* In `ReportTaskDetailTable.jsx`, added a `statusBadgeClass` mapping for status-specific badge colors and updated table row backgrounds and badge styles to visually distinguish task statuses. Rows and badges now use emerald, amber, and sky color themes for "Completed", "Pending", and "In Progress" respectively. [[1]](diffhunk://#diff-4d6f58fd6e26a633520df702b991281d3731725a866b53db2d16fe0b57ee448fR3-R8) [[2]](diffhunk://#diff-4d6f58fd6e26a633520df702b991281d3731725a866b53db2d16fe0b57ee448fL39-R56)
* In `TaskTable.jsx`, updated the color coding for the "In Progress" status badge to use a blue (sky) theme instead of yellow, making it distinct from "Pending".

**Excel Export Styling Improvements:**

* In `ReportPage.jsx`, introduced a new color constant for "In Progress" (`inProgressBlue`) and applied status-specific cell background colors and bold text to the status column in exported Excel reports. Now, "Completed", "In Progress", and "Pending" statuses have their own distinct colors in the exported file. [[1]](diffhunk://#diff-f8b20cd7da02cb685c5d8dc20d81b53736cd9ec6143f9e17c9e4b6d4e6ce9414R16) [[2]](diffhunk://#diff-f8b20cd7da02cb685c5d8dc20d81b53736cd9ec6143f9e17c9e4b6d4e6ce9414R413-R427)
* Applied header styling (background color and bold text) to the first row of the Excel sheet, and ensured that all data rows have a consistent white background and left alignment, improving the overall readability of the exported report. [[1]](diffhunk://#diff-f8b20cd7da02cb685c5d8dc20d81b53736cd9ec6143f9e17c9e4b6d4e6ce9414R395-R400) [[2]](diffhunk://#diff-f8b20cd7da02cb685c5d8dc20d81b53736cd9ec6143f9e17c9e4b6d4e6ce9414R413-R427)